### PR TITLE
SSL looking for file with incorrect extension

### DIFF
--- a/commands
+++ b/commands
@@ -48,8 +48,8 @@ case "$1" in
 
     SSL="$DOKKU_ROOT/$APP/ssl/$cert_name"
 
-    [ -f "$SSL.cert" ] || {
-      echo "$SSL.cert does not exist"
+    [ -f "$SSL.crt" ] || {
+      echo "$SSL.crt does not exist"
       exit 1
     }
 


### PR DESCRIPTION
SSL is looking for '.cert' file instead of '.crt'.  Ref GH-5
