### PR TITLE
Update to use also app IP

### DIFF
--- a/commands
+++ b/commands
@@ -37,13 +37,14 @@ case "$1" in
     fi
 
     domains="${*:3}"
+    IP=$(< "$DOKKU_ROOT/$APP/IP")
     PORT=$(< "$DOKKU_ROOT/$APP/PORT")
 
     echo "$domains" > $DOMAINS_FILE
 
     # default nginx.conf
   cat<<EOF > $DOKKU_ROOT/$APP/nginx-domains.conf
-upstream $APP-domains { server 127.0.0.1:$PORT; }
+upstream $APP-domains { server $IP:$PORT; }
 server {
   listen      [::]:80;
   listen      80;


### PR DESCRIPTION
It's needed in Dokku configuration where is virtualhost naming has been enabled (i.e. DigitalOcean). In this cases PORT for all apps is might be identical (5000) but IP are different (172.17.0.*).
